### PR TITLE
chore: fix catalog Location targets glob

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,5 +5,4 @@ metadata:
   description: Catalog entities for argocd-app-updater-action.
 spec:
   targets:
-    - ./catalog/*.yaml
     - ./catalog/**/*.yaml


### PR DESCRIPTION
## Summary
- Remove `./catalog/*.yaml` from Location `spec.targets` — no YAML files exist directly in `catalog/` (all entities live under `catalog/apps/`). Backstage throws a `NotFoundError` when a glob matches zero files, which was blocking catalog ingestion and preventing the `argocd-app-updater-action` component from appearing in Backyard.

## Test plan
- [ ] Verify `argocd-app-updater-action` component appears in Backyard after merge