### PR TITLE
chore: migrate Backyard badges + FY27 annotations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hipagesgroup/site-reliability-engineering

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Link to argocd-app-updater-action in hipages Developer Portal, Component: argocd-app-updater-action](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/argocd-app-updater-action/badge/pingback "Link to argocd-app-updater-action in hipages Developer Portal")](https://backyard.prod.hipages.com.au/catalog/default/component/argocd-app-updater-action)
-[![Entity owner badge, owner: site-reliability-engineering](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/argocd-app-updater-action/badge/owner "Entity owner badge")](https://backyard.prod.hipages.com.au/catalog/default/component/argocd-app-updater-action)
+[![Link to argocd-app-updater-action in hipages Developer Portal, Component: argocd-app-updater-action](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/argocd-app-updater-action/badge/pingback "Link to argocd-app-updater-action in hipages Developer Portal")](https://backyard.internal.prod.hipages.com.au/catalog/default/component/argocd-app-updater-action)
+[![Entity owner badge, owner: site-reliability-engineering](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/argocd-app-updater-action/badge/owner "Entity owner badge")](https://backyard.internal.prod.hipages.com.au/catalog/default/component/argocd-app-updater-action)
 # argocd-app-updater-action
 
 Automatically update ArgoCD application manifests via pull requests.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Link to argocd-app-updater-action in hipages Developer Portal, Component: argocd-app-updater-action](https://backyard.k8s.hipages.com.au/api/badges/entity/default/Component/argocd-app-updater-action/badge/pingback "Link to argocd-app-updater-action in hipages Developer Portal")](https://backyard.k8s.hipages.com.au/catalog/default/Component/argocd-app-updater-action)
-[![Entity owner badge, owner: site-reliability-engineering](https://backyard.k8s.hipages.com.au/api/badges/entity/default/Component/argocd-app-updater-action/badge/owner "Entity owner badge")](https://backyard.k8s.hipages.com.au/catalog/default/Component/argocd-app-updater-action)
+[![Link to argocd-app-updater-action in hipages Developer Portal, Component: argocd-app-updater-action](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/argocd-app-updater-action/badge/pingback "Link to argocd-app-updater-action in hipages Developer Portal")](https://backyard.prod.hipages.com.au/catalog/default/component/argocd-app-updater-action)
+[![Entity owner badge, owner: site-reliability-engineering](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/argocd-app-updater-action/badge/owner "Entity owner badge")](https://backyard.prod.hipages.com.au/catalog/default/component/argocd-app-updater-action)
 # argocd-app-updater-action
 
 Automatically update ArgoCD application manifests via pull requests.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Link to argocd-app-updater-action in hipages Developer Portal, Component: argocd-app-updater-action](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/argocd-app-updater-action/badge/pingback "Link to argocd-app-updater-action in hipages Developer Portal")](https://backyard.internal.prod.hipages.com.au/catalog/default/component/argocd-app-updater-action)
-[![Entity owner badge, owner: site-reliability-engineering](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/argocd-app-updater-action/badge/owner "Entity owner badge")](https://backyard.internal.prod.hipages.com.au/catalog/default/component/argocd-app-updater-action)
+[![Link to argocd-app-updater-action in hipages Developer Portal, Component: argocd-app-updater-action](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/argocd-app-updater-action/badge/pingback "Link to argocd-app-updater-action in hipages Developer Portal")](https://backyard.prod.hipages.com.au/catalog/default/component/argocd-app-updater-action)
+[![Entity owner badge, owner: site-reliability-engineering](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/argocd-app-updater-action/badge/owner "Entity owner badge")](https://backyard.prod.hipages.com.au/catalog/default/component/argocd-app-updater-action)
 # argocd-app-updater-action
 
 Automatically update ArgoCD application manifests via pull requests.


### PR DESCRIPTION
Migrates Backyard portal badges in README from `backyard.k8s.hipages.com.au` to `backyard.prod.hipages.com.au` (lowercasing entity-kind path segments), syncs `github.com/team-slug` annotations on System/Component catalog entities to match `spec.owner`, and adds CODEOWNERS where missing.